### PR TITLE
Support a single gps instead of two

### DIFF
--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -10,26 +10,16 @@ int32 wind_sensor_2_speed
 int32 wind_sensor_2_direction
 int32 wind_sensor_2_reference
 
-string   gps_0_timestamp
-float64  gps_0_latitude
-float64  gps_0_longitude
-bool     gps_0_latitude_loc
-bool     gps_0_longitude_loc
-int32    gps_0_groundspeed
-int32    gps_0_track_made_good
-int32    gps_0_true_heading
-int32    gps_0_magnetic_variation
-bool     gps_0_magnetic_variation_sense
-string   gps_1_timestamp
-float64  gps_1_latitude
-float64  gps_1_longitude
-bool     gps_1_latitude_loc
-bool     gps_1_longitude_loc
-int32    gps_1_groundspeed
-int32    gps_1_track_made_good
-int32    gps_1_true_heading
-int32    gps_1_magnetic_variation
-bool     gps_1_magnetic_variation_sense
+string   gps_timestamp
+float64  gps_latitude
+float64  gps_longitude
+bool     gps_latitude_loc
+bool     gps_longitude_loc
+int32    gps_groundspeed
+int32    gps_track_made_good
+int32    gps_true_heading
+int32    gps_magnetic_variation
+bool     gps_magnetic_variation_sense
 
 int32 accelerometer_x_axis_acceleration
 int32 accelerometer_y_axis_acceleration


### PR DESCRIPTION
There is actually only 1 gps. 
Right now I think both the network table and 
boat controller code references gps_0 and gps_1.

One option is to keep the code the same and by
convention choose to use only gps_0, for example.
The second option is to adjust our respective code
to only reference the singular "gps" message fields. 