### PR TITLE
Add fields for gps data received from can and ais

### DIFF
--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -10,16 +10,27 @@ int32 wind_sensor_2_speed
 int32 wind_sensor_2_direction
 int32 wind_sensor_2_reference
 
-string   gps_timestamp
-float64  gps_latitude
-float64  gps_longitude
-bool     gps_latitude_loc
-bool     gps_longitude_loc
-int32    gps_groundspeed
-int32    gps_track_made_good
-int32    gps_true_heading
-int32    gps_magnetic_variation
-bool     gps_magnetic_variation_sense
+string   gps_can_timestamp
+float64  gps_can_latitude
+float64  gps_can_longitude
+bool     gps_can_latitude_loc
+bool     gps_can_longitude_loc
+int32    gps_can_groundspeed
+int32    gps_can_track_made_good
+int32    gps_can_true_heading
+int32    gps_can_magnetic_variation
+bool     gps_can_magnetic_variation_sense
+
+string   gps_ais_timestamp
+float64  gps_ais_latitude
+float64  gps_ais_longitude
+bool     gps_ais_latitude_loc
+bool     gps_ais_longitude_loc
+int32    gps_ais_groundspeed
+int32    gps_ais_track_made_good
+int32    gps_ais_true_heading
+int32    gps_ais_magnetic_variation
+bool     gps_ais_magnetic_variation_sense
 
 int32 accelerometer_x_axis_acceleration
 int32 accelerometer_y_axis_acceleration


### PR DESCRIPTION
We have one gps that currently transfers data via CAN.
Eventually, we also want to retrieve gps data from the AIS.