### PR TITLE
Update msg fields to include units

### DIFF
--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -3,40 +3,40 @@
 
 int32 sailencoder_degrees 
 
-int32 wind_sensor_1_speed_knots
-int32 wind_sensor_1_direction_degrees
-int32 wind_sensor_2_speed_knots
-int32 wind_sensor_2_direction_degrees
-int32 wind_sensor_3_speed_knots
-int32 wind_sensor_3_direction_degrees
+float32 wind_sensor_1_speed_knots
+int32   wind_sensor_1_angle_degrees
+float32 wind_sensor_2_speed_knots
+int32   wind_sensor_2_angle_degrees
+float32 wind_sensor_3_speed_knots
+int32   wind_sensor_3_angle_degrees
 
-string   gps_can_timestamp_utc
-float64  gps_can_latitude_degreeMinutes
-float64  gps_can_longitude_degreeMinutes
-int32    gps_can_groundspeed_knots
-int32    gps_can_track_made_good_degrees
-int32    gps_can_true_heading_degrees
-int32    gps_can_magnetic_variation_degrees
-bool     gps_can_state
+string  gps_can_timestamp_utc
+float32 gps_can_latitude_degreeMinutes
+float32 gps_can_longitude_degreeMinutes
+float32 gps_can_groundspeed_knots
+float32 gps_can_track_made_good_degrees
+float32 gps_can_true_heading_degrees
+float32 gps_can_magnetic_variation_degrees
+bool    gps_can_state
 
-string   gps_ais_timestamp_utc
-float64  gps_ais_latitude_degreeMinutes
-float64  gps_ais_longitude_degreeMinutes
-int32    gps_ais_groundspeed_knots
-int32    gps_ais_track_made_good_degrees
-int32    gps_ais_true_heading_degrees
-int32    gps_ais_magnetic_variation_degrees
-bool     gps_ais_state
+string  gps_ais_timestamp_utc
+float32 gps_ais_latitude_degreeMinutes
+float32 gps_ais_longitude_degreeMinutes
+float32 gps_ais_groundspeed_knots
+float32 gps_ais_track_made_good_degrees
+float32 gps_ais_true_heading_degrees
+float32 gps_ais_magnetic_variation_degrees
+bool    gps_ais_state
 
-int32    winch_main_angle_degrees
-int32    winch_jib_angle_degrees
-int32    rudder_port_angle_degrees
-int32    rudder_stbd_angle_degrees
+int32   winch_main_angle_degrees
+int32   winch_jib_angle_degrees
+float32 rudder_port_angle_degrees
+float32 rudder_stbd_angle_degrees
 
-int32 accelerometer_x_force_millig
-int32 accelerometer_y_force_millig
-int32 accelerometer_z_force_millig
+float32 accelerometer_x_force_millig
+float32 accelerometer_y_force_millig
+float32 accelerometer_z_force_millig
 
-int32 gyroscope_x_velocity_millidegreesps 
-int32 gyroscope_y_velocity_millidegreesps
-int32 gyroscope_z_velocity_millidegreesps
+float32 gyroscope_x_velocity_millidegreesps 
+float32 gyroscope_y_velocity_millidegreesps
+float32 gyroscope_z_velocity_millidegreesps

--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -1,36 +1,35 @@
-int32 boom_angle_sensor_angle
+// For more information refer to: 
+// https://ubcsailbot.atlassian.net/wiki/spaces/ADA2/pages/506167525/CAN+Bus+Inputs+and+Outputs
 
-int32 wind_sensor_0_speed
-int32 wind_sensor_0_direction
-int32 wind_sensor_0_reference
-int32 wind_sensor_1_speed
-int32 wind_sensor_1_direction
-int32 wind_sensor_1_reference
-int32 wind_sensor_2_speed
-int32 wind_sensor_2_direction
-int32 wind_sensor_2_reference
+int32 sailencoder_degrees 
 
-string   gps_0_timestamp
-float64  gps_0_latitude
-float64  gps_0_longitude
-bool     gps_0_latitude_loc
-bool     gps_0_longitude_loc
-int32    gps_0_groundspeed
-int32    gps_0_track_made_good
-int32    gps_0_true_heading
-int32    gps_0_magnetic_variation
-bool     gps_0_magnetic_variation_sense
-string   gps_1_timestamp
-float64  gps_1_latitude
-float64  gps_1_longitude
-bool     gps_1_latitude_loc
-bool     gps_1_longitude_loc
-int32    gps_1_groundspeed
-int32    gps_1_track_made_good
-int32    gps_1_true_heading
-int32    gps_1_magnetic_variation
-bool     gps_1_magnetic_variation_sense
+int32 wind_sensor_1_speed_knots
+int32 wind_sensor_1_direction_degrees
+int32 wind_sensor_2_speed_knots
+int32 wind_sensor_2_direction_degrees
+int32 wind_sensor_3_speed_knots
+int32 wind_sensor_3_direction_degrees
 
-int32 accelerometer_x_axis_acceleration
-int32 accelerometer_y_axis_acceleration
-int32 accelerometer_z_axis_acceleration
+string   gps_can_timestamp_yymmddhhmmss
+float64  gps_can_latitude_degrees
+float64  gps_can_longitude_degrees
+int32    gps_can_groundspeed_knots
+int32    gps_can_track_made_good_degrees
+int32    gps_can_true_heading_degrees
+int32    gps_can_magnetic_variation_degrees
+
+string   gps_ais_timestamp_yymmddhhmmss
+float64  gps_ais_latitude_degrees
+float64  gps_ais_longitude_degrees
+int32    gps_ais_groundspeed_knots
+int32    gps_ais_track_made_good_degrees
+int32    gps_ais_true_heading_degrees
+int32    gps_ais_magnetic_variation_degrees
+
+int32 accelerometer_x_force_millig
+int32 accelerometer_y_force_millig
+int32 accelerometer_z_force_millig
+
+int32 gyroscope_x_velocity_millidegreesps 
+int32 gyroscope_y_velocity_millidegreesps
+int32 gyroscope_z_velocity_millidegreesps

--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -11,20 +11,27 @@ int32 wind_sensor_3_speed_knots
 int32 wind_sensor_3_direction_degrees
 
 string   gps_can_timestamp_utc
-float64  gps_can_latitude_degrees
-float64  gps_can_longitude_degrees
+float64  gps_can_latitude_degreeMinutes
+float64  gps_can_longitude_degreeMinutes
 int32    gps_can_groundspeed_knots
 int32    gps_can_track_made_good_degrees
 int32    gps_can_true_heading_degrees
 int32    gps_can_magnetic_variation_degrees
+bool     gps_can_state
 
 string   gps_ais_timestamp_utc
-float64  gps_ais_latitude_degrees
-float64  gps_ais_longitude_degrees
+float64  gps_ais_latitude_degreeMinutes
+float64  gps_ais_longitude_degreeMinutes
 int32    gps_ais_groundspeed_knots
 int32    gps_ais_track_made_good_degrees
 int32    gps_ais_true_heading_degrees
 int32    gps_ais_magnetic_variation_degrees
+bool     gps_ais_state
+
+int32    winch_main_angle_degrees
+int32    winch_jib_angle_degrees
+int32    rudder_port_angle_degrees
+int32    rudder_stbd_angle_degrees
 
 int32 accelerometer_x_force_millig
 int32 accelerometer_y_force_millig

--- a/msg/Sensors.msg
+++ b/msg/Sensors.msg
@@ -10,7 +10,7 @@ int32 wind_sensor_2_direction_degrees
 int32 wind_sensor_3_speed_knots
 int32 wind_sensor_3_direction_degrees
 
-string   gps_can_timestamp_yymmddhhmmss
+string   gps_can_timestamp_utc
 float64  gps_can_latitude_degrees
 float64  gps_can_longitude_degrees
 int32    gps_can_groundspeed_knots
@@ -18,7 +18,7 @@ int32    gps_can_track_made_good_degrees
 int32    gps_can_true_heading_degrees
 int32    gps_can_magnetic_variation_degrees
 
-string   gps_ais_timestamp_yymmddhhmmss
+string   gps_ais_timestamp_utc
 float64  gps_ais_latitude_degrees
 float64  gps_ais_longitude_degrees
 int32    gps_ais_groundspeed_knots


### PR DESCRIPTION
The msg fields now include units for greater clarity.
These units reflect the data that is directly outputted from 
the sensors as noted in:
https://ubcsailbot.atlassian.net/wiki/spaces/ADA2/pages/506167525/CAN+Bus+Inputs+and+Outputs

Note: From what I've been told, the ais' gps is intended to be 
used as a backup. These fields are not currently being stored 
in the network table. Further investigation is required. 