### PR TITLE
Add lowWindConditions field

### DIFF
--- a/msg/globalWind.msg
+++ b/msg/globalWind.msg
@@ -1,2 +1,3 @@
 float64 directionDegrees
 float64 speedKmph
+bool    lowWindConditions


### PR DESCRIPTION
This field is used to communicate if the wind is too light to sail normally. Part of issue #277 in local-pathfinding